### PR TITLE
fix(docker-promote): update regression on copy default

### DIFF
--- a/cmd/vela-artifactory/main.go
+++ b/cmd/vela-artifactory/main.go
@@ -159,6 +159,7 @@ func main() {
 			FilePath: string("/vela/parameters/artifactory/docker_promote/copy,/vela/secrets/artifactory/docker_promote/copy"),
 			Name:     "docker_promote.copy",
 			Usage:    "set to copy instead of moving the image",
+			Value:    true,
 		},
 		&cli.BoolFlag{
 			EnvVars:  []string{"PARAMETER_PROPS_PROMOTE", "DOCKER_PROMOTE_SET_PROP_PROMOTE"},


### PR DESCRIPTION
Regression change on commit defaulting from `true` to `false`:
https://github.com/go-vela/vela-artifactory/commit/0f0fb2bb75cbd85a4da8eaac3ebda63baa840f9f#diff-c78a306fb86c0ca8c9c37de7aaf06369L140-L141