### PR TITLE
chore: convert true to always pull policy

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -16,7 +16,7 @@ Sample of copying an artifact:
 steps:
   - name: copy_artifacts
     image: target/vela-artifactory:v0.2.0
-    pull: true
+    pull: always
     parameters:
       action: copy
       path: libs-snapshot-local/foo.txt
@@ -30,7 +30,7 @@ Sample of deleting an artifact:
 steps:
   - name: delete_artifacts
     image: target/vela-artifactory:v0.2.0
-    pull: true
+    pull: always
     parameters:
       action: delete
       path: libs-snapshot-local/foo.txt
@@ -43,7 +43,7 @@ Sample of setting properties on an artifact:
 steps:
   - name: set_properties_artifacts
     image: target/vela-artifactory:v0.2.0
-    pull: true
+    pull: always
     parameters:
       action: set-prop
       path: libs-snapshot-local/foo.txt
@@ -63,7 +63,7 @@ Sample of uploading an artifact:
 steps:
   - name: upload_artifacts
     image: target/vela-artifactory:v0.2.0
-    pull: true
+    pull: always
     parameters:
       action: upload
       path: libs-snapshot-local/
@@ -80,7 +80,7 @@ Sample of pretending to upload an artifact:
 steps:
   - name: upload_artifacts
     image: target/vela-artifactory:v0.2.0
-    pull: true
+    pull: always
     parameters:
       action: upload
 +     dry_run: true
@@ -98,7 +98,7 @@ Sample of using docker-promote on an artifact:
 steps:
   - name: docker_promote_artifacts
     image: target/vela-artifactory:v0.2.0
-    pull: true
+    pull: always
     parameters:
       action: docker-promote
       target_repo: libs-snapshot-local
@@ -118,7 +118,7 @@ You can use Vela secrets to substitute sensitive values at runtime:
 steps:
   - name: copy_artifacts
     image: target/vela-artifactory:v0.2.0
-    pull: true
+    pull: always
 +   secrets: [ artifactory_username, artifactory_password ]
     parameters:
       action: copy

--- a/DOCS.md
+++ b/DOCS.md
@@ -8,14 +8,14 @@ Registry: https://hub.docker.com/r/target/vela-artifactory
 
 ## Usage
 
-_The plugin supports reading all parameters via environment variables or files. Values set as a file take precedence over default values set from the environment._
+**NOTE: It is not recommended to use `latest` as the tag for the Docker image. Users should use a semantically versioned tag instead.**
 
 Sample of copying an artifact:
 
 ```yaml
 steps:
   - name: copy_artifacts
-    image: target/vela-artifactory:v0.2.0
+    image: target/vela-artifactory:latest
     pull: always
     parameters:
       action: copy
@@ -29,7 +29,7 @@ Sample of deleting an artifact:
 ```yaml
 steps:
   - name: delete_artifacts
-    image: target/vela-artifactory:v0.2.0
+    image: target/vela-artifactory:latest
     pull: always
     parameters:
       action: delete
@@ -42,7 +42,7 @@ Sample of setting properties on an artifact:
 ```yaml
 steps:
   - name: set_properties_artifacts
-    image: target/vela-artifactory:v0.2.0
+    image: target/vela-artifactory:latest
     pull: always
     parameters:
       action: set-prop
@@ -62,7 +62,7 @@ Sample of uploading an artifact:
 ```yaml
 steps:
   - name: upload_artifacts
-    image: target/vela-artifactory:v0.2.0
+    image: target/vela-artifactory:latest
     pull: always
     parameters:
       action: upload
@@ -79,7 +79,7 @@ Sample of pretending to upload an artifact:
 ```diff
 steps:
   - name: upload_artifacts
-    image: target/vela-artifactory:v0.2.0
+    image: target/vela-artifactory:latest
     pull: always
     parameters:
       action: upload
@@ -97,7 +97,7 @@ Sample of using docker-promote on an artifact:
 ```yaml
 steps:
   - name: docker_promote_artifacts
-    image: target/vela-artifactory:v0.2.0
+    image: target/vela-artifactory:latest
     pull: always
     parameters:
       action: docker-promote
@@ -117,7 +117,7 @@ You can use Vela secrets to substitute sensitive values at runtime:
 ```diff
 steps:
   - name: copy_artifacts
-    image: target/vela-artifactory:v0.2.0
+    image: target/vela-artifactory:latest
     pull: always
 +   secrets: [ artifactory_username, artifactory_password ]
     parameters:
@@ -130,6 +130,11 @@ steps:
 ```
 
 ## Parameters
+
+**NOTE:**
+
+* the plugin supports reading all parameters via environment variables or files
+* values set from a file take precedence over values set from the environment
 
 The following parameters are used to configure the image:
 
@@ -153,7 +158,6 @@ The following parameters are used to configure the `copy` action:
 | `flat`      | enables removing source directory hierarchy         | `false`  | `false` |
 | `recursive` | enables copying sub-directories for the artifact(s) | `false`  | `false` |
 | `target`    | target path to copy artifact(s) to                  | `true`   | `N/A`   |
-
 
 #### Delete
 


### PR DESCRIPTION
This PR updates the existing docs for the `pull` attribute to match the newly created pull policies.

To accomplish this, I performed a find and replace for converting

```
pull: true
```

to

```
pull: always
```

Also found in this PR is updating the tag for the Docker image we reference to `latest` 👍 