### PR TITLE
feat: use new version pkg

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
     - name: clone
       uses: actions/checkout@v2
+      with:
+        # ensures we fetch tag history for the repository
+        fetch-depth: 0
 
     - name: setup
       run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -17,15 +17,17 @@ jobs:
     - name: clone
       uses: actions/checkout@v2
 
+    - name: setup
+      run: |
+        # setup git tag in Actions environment
+        echo "GITHUB_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
     - name: build
       env:
         GOOS: linux
         CGO_ENABLED: '0'
       run: |
-        go build -a \
-          -ldflags '-s -w -extldflags "-static"' \
-          -o release/vela-artifactory \
-          github.com/go-vela/vela-artifactory/cmd/vela-artifactory
+        make build-static-ci
 
     - name: publish
       uses: elgohr/Publish-Docker-Github-Action@master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
     - name: clone
       uses: actions/checkout@v2
+      with:
+        # ensures we fetch tag history for the repository
+        fetch-depth: 0
 
     - name: build
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,7 @@ jobs:
         GOOS: linux
         CGO_ENABLED: '0'
       run: |
-        go build -a \
-          -ldflags '-s -w -extldflags "-static"' \
-          -o release/vela-artifactory \
-          github.com/go-vela/vela-artifactory/cmd/vela-artifactory
+        make build-static-ci
 
     - name: publish
       uses: elgohr/Publish-Docker-Github-Action@master

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,30 @@
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 
+# capture the current date we build the application from
+BUILD_DATE = $(shell date +%Y-%m-%dT%H:%M:%SZ)
+
+# check if a git commit sha is already set
+ifndef GITHUB_SHA
+	# capture the current git commit sha we build the application from
+	GITHUB_SHA = $(shell git rev-parse HEAD)
+endif
+
+# check if a git tag is already set
+ifndef GITHUB_TAG
+	# capture the current git tag we build the application from
+	GITHUB_TAG = $(shell git describe --tag --abbrev=0)
+endif
+
+# check if a go version is already set
+ifndef GOLANG_VERSION
+	# capture the current go version we build the application from
+	GOLANG_VERSION = $(shell go version | awk '{ print $$3 }')
+endif
+
+# create a list of linker flags for building the golang application
+LD_FLAGS = -X github.com/go-vela/vela-artifactory/version.Commit=${GITHUB_SHA} -X github.com/go-vela/vela-artifactory/version.Date=${BUILD_DATE} -X github.com/go-vela/vela-artifactory/version.Go=${GOLANG_VERSION} -X github.com/go-vela/vela-artifactory/version.Tag=${GITHUB_TAG}
+
 # The `clean` target is intended to clean the workspace
 # and prepare the local changes for submission.
 #
@@ -90,6 +114,7 @@ build:
 	@echo "### Building release/vela-artifactory binary"
 	GOOS=linux CGO_ENABLED=0 \
 		go build -a \
+		-ldflags '${LD_FLAGS}' \
 		-o release/vela-artifactory \
 		github.com/go-vela/vela-artifactory/cmd/vela-artifactory
 
@@ -103,7 +128,21 @@ build-static:
 	@echo "### Building static release/vela-artifactory binary"
 	GOOS=linux CGO_ENABLED=0 \
 		go build -a \
-		-ldflags '-s -w -extldflags "-static"' \
+		-ldflags '-s -w -extldflags "-static" ${LD_FLAGS}' \
+		-o release/vela-artifactory \
+		github.com/go-vela/vela-artifactory/cmd/vela-artifactory
+
+# The `build-static-ci` target is intended to compile
+# the Go source code into a statically linked binary
+# when used within a CI environment.
+#
+# Usage: `make build-static-ci`
+.PHONY: build-static-ci
+build-static-ci:
+	@echo
+	@echo "### Building CI static release/vela-artifactory binary"
+	@go build -a \
+		-ldflags '-s -w -extldflags "-static" ${LD_FLAGS}' \
 		-o release/vela-artifactory \
 		github.com/go-vela/vela-artifactory/cmd/vela-artifactory
 

--- a/cmd/vela-artifactory/main.go
+++ b/cmd/vela-artifactory/main.go
@@ -5,8 +5,12 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"time"
+
+	"github.com/go-vela/vela-artifactory/version"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -32,8 +36,9 @@ func main() {
 
 	// Plugin Metadata
 
-	app.Compiled = time.Now()
 	app.Action = run
+	app.Compiled = time.Now()
+	app.Version = version.New().Semantic()
 
 	// Plugin Flags
 
@@ -219,6 +224,15 @@ func main() {
 
 // run executes the plugin based off the configuration provided.
 func run(c *cli.Context) error {
+	// capture the version information as pretty JSON
+	v, err := json.MarshalIndent(version.New(), "", "  ")
+	if err != nil {
+		return err
+	}
+
+	// output the version information to stdout
+	fmt.Fprintf(os.Stdout, "%s\n", string(v))
+
 	// set the log level for the plugin
 	switch c.String("log.level") {
 	case "t", "trace", "Trace", "TRACE":
@@ -295,7 +309,7 @@ func run(c *cli.Context) error {
 	}
 
 	// validate the plugin
-	err := p.Validate()
+	err = p.Validate()
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,14 @@ module github.com/go-vela/vela-artifactory
 go 1.13
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/gin-gonic/gin v1.6.3 // indirect
 	github.com/go-playground/validator/v10 v10.3.0 // indirect
+	github.com/go-vela/types v0.6.1-0.20201019123446-226d0cc72538
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/jfrog/gofrog v1.0.6 // indirect
@@ -31,5 +33,4 @@ require (
 	golang.org/x/text v0.3.3 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1 // indirect
-	gopkg.in/yaml.v2 v2.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
@@ -7,6 +9,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/buger/jsonparser v0.0.0-20180910192245-6acdf747ae99/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
+github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3 h1:q+sMKdA6L8LyGVudTkpGoC73h6ak2iWSPFiFo/pFOU8=
+github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3/go.mod h1:5hCug3EZaHXU3FdCA3gJm0YTNi+V+ooA2qNTiVpky4A=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -60,6 +64,8 @@ github.com/go-playground/validator/v10 v10.2.0 h1:KgJ0snyC2R9VXYN2rneOtQcw5aHQB1
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.3.0 h1:nZU+7q+yJoFmwvNgv/LnPUkwPal62+b2xXj0AU1Es7o=
 github.com/go-playground/validator/v10 v10.3.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
+github.com/go-vela/types v0.6.1-0.20201019123446-226d0cc72538 h1:ck0Ylos/ExUCluEqQgVxKrTZ21nsup0VZT31sWqTU4Y=
+github.com/go-vela/types v0.6.1-0.20201019123446-226d0cc72538/go.mod h1:6r6mWIPrTANBpHwAFAIii64VKtzlAzVagbm/wX5bHHk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -119,6 +125,7 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
+github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/Masterminds/semver"
+
+	"github.com/go-vela/types/version"
+)
+
+var (
+	// Arch represents the architecture information for the package.
+	Arch = runtime.GOARCH
+	// Commit represents the git commit information for the package.
+	Commit string
+	// Compiler represents the compiler information for the package.
+	Compiler = runtime.Compiler
+	// Date represents the build date information for the package.
+	Date string
+	// Go represents the golang version information for the package.
+	Go string
+	// OS represents the operating system information for the package.
+	OS = runtime.GOOS
+	// Tag represents the git tag information for the package.
+	Tag string
+)
+
+// New creates a new version object for Vela that is used throughout the application.
+func New() *version.Version {
+	v, err := semver.NewVersion(Tag)
+	if err != nil {
+		fmt.Println(fmt.Errorf("unable to parse semantic version for %s: %v", Tag, err))
+	}
+
+	return &version.Version{
+		Canonical:  Tag,
+		Major:      v.Major(),
+		Minor:      v.Minor(),
+		Patch:      v.Patch(),
+		PreRelease: v.Prerelease(),
+		Metadata: version.Metadata{
+			Architecture:    Arch,
+			BuildDate:       Date,
+			Compiler:        Compiler,
+			GitCommit:       Commit,
+			GoVersion:       Go,
+			OperatingSystem: OS,
+		},
+	}
+}


### PR DESCRIPTION
Dependent on https://github.com/go-vela/types/pull/112

Updating to the new `go-vela/types/version` package to improve the information provided surrounding the application.

When I run `make run` locally, here is the output:

```json
{
  "canonical": "v0.3.0",
  "major": 0,
  "minor": 3,
  "patch": 0,
  "metadata": {
    "architecture": "amd64",
    "build_date": "2020-10-19T13:03:26Z",
    "compiler": "gc",
    "git_commit": "59416f2e3ee5f6c3a2b63dae9a5555b075a37946",
    "go_version": "go1.15.2",
    "operating_system": "linux"
  }
}
<more logs>
```

**NOTE: This also updates the GitHub Actions pipelines to use our `make` commands for building the binary.**