### PR TITLE
fix(upload): return error on upload failures

### DIFF
--- a/cmd/vela-artifactory/upload.go
+++ b/cmd/vela-artifactory/upload.go
@@ -53,20 +53,14 @@ func (u *Upload) Exec(cli *artifactory.ArtifactoryServicesManager) error {
 		p.Retries = 3
 
 		// send API call to upload artifacts in Artifactory
-		fmt.Printf("uploading")
-		_, totalUploaded, totalFailed, err := cli.UploadFiles(p)
+		_, _, totalFailed, err := cli.UploadFiles(p)
 		if err != nil {
 			return err
 		}
 
-		if totalUploaded > 0 {
-			logrus.Info("successfully uploaded %d artifacts", totalUploaded)
-
-		}
-
 		// return an error when artifacts fail to upload
 		if totalFailed > 0 {
-			err = fmt.Errorf("failed to upload %d artifacts", totalFailed)
+			err = fmt.Errorf("failed uploading %d artifacts", totalFailed)
 			return err
 		}
 	}

--- a/cmd/vela-artifactory/upload.go
+++ b/cmd/vela-artifactory/upload.go
@@ -53,8 +53,20 @@ func (u *Upload) Exec(cli *artifactory.ArtifactoryServicesManager) error {
 		p.Retries = 3
 
 		// send API call to upload artifacts in Artifactory
-		_, _, _, err := cli.UploadFiles(p)
+		fmt.Printf("uploading")
+		_, totalUploaded, totalFailed, err := cli.UploadFiles(p)
 		if err != nil {
+			return err
+		}
+
+		if totalUploaded > 0 {
+			logrus.Info("successfully uploaded %d artifacts", totalUploaded)
+
+		}
+
+		// return an error when artifacts fail to upload
+		if totalFailed > 0 {
+			err = fmt.Errorf("failed to upload %d artifacts", totalFailed)
 			return err
 		}
 	}


### PR DESCRIPTION
closes https://github.com/go-vela/community/issues/32

errors are not returned when artifacts fail to upload, causing containers to produce false positive exit codes

#### experience on master
![Screen Shot 2021-01-20 at 3 20 40 PM](https://user-images.githubusercontent.com/48764154/105241381-35dbf780-5b33-11eb-8974-dcf13e20d95a.png)

#### after
![Screen Shot 2021-01-20 at 3 19 15 PM](https://user-images.githubusercontent.com/48764154/105241394-3aa0ab80-5b33-11eb-8c29-177491b7f06f.png)
