### PR TITLE
fix(auth): username is optional if apikey is provided

### DIFF
--- a/cmd/vela-artifactory/config.go
+++ b/cmd/vela-artifactory/config.go
@@ -47,8 +47,11 @@ func (c *Config) New() (*artifactory.ArtifactoryServicesManager, error) {
 
 	// set URL for Artifactory details
 	details.SetUrl(c.URL)
-	// set user name for Artifactory details
-	details.SetUser(c.Username)
+	// check if username is provided
+	if len(c.Username) > 0 {
+		// set user name for Artifactory details
+		details.SetUser(c.Username)
+	}
 
 	// check if API key is provided
 	if len(c.APIKey) > 0 {
@@ -102,8 +105,8 @@ func (c *Config) Validate() error {
 
 	// check if dry run is disabled
 	if !c.DryRun {
-		// verify username is provided
-		if len(c.Username) == 0 {
+		// verify username is provided if APIKey is empty
+		if len(c.Username) == 0 && len(c.APIKey) == 0 {
 			return fmt.Errorf("no config username provided")
 		}
 

--- a/cmd/vela-artifactory/config_test.go
+++ b/cmd/vela-artifactory/config_test.go
@@ -130,9 +130,22 @@ func TestArtifactory_Config_Validate_NoUsername(t *testing.T) {
 	c := &Config{
 		Action:   "copy",
 		DryRun:   false,
-		APIKey:   "superSecretAPIKey",
 		Password: "superSecretPassword",
 		URL:      "https://myarti.com/artifactory",
+	}
+
+	err := c.Validate()
+	if err == nil {
+		t.Errorf("Validate should have returned err")
+	}
+}
+
+func TestArtifactory_Config_Validate_NoAuth(t *testing.T) {
+	// setup types
+	c := &Config{
+		Action: "copy",
+		DryRun: false,
+		URL:    "https://myarti.com/artifactory",
 	}
 
 	err := c.Validate()


### PR DESCRIPTION
Artifactory does not require the username to be present when utilizing the API key.