### PR TITLE
docs: update env var and file parameter info

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -109,7 +109,7 @@ steps:
       docker_registry: octocat/hello-world
       tag: latest
       target_docker_registry: octocat/hello-world
-      target_tags: "${BUILD_COMMIT:0:8}"
+      target_tags: "${VELA_BUILD_COMMIT:0:8}"
 ```
 
 ## Secrets
@@ -117,6 +117,14 @@ steps:
 > **NOTE:** Users should refrain from configuring sensitive information in your pipeline in plain text.
 
 ### Internal
+
+The plugin accepts the following `parameters` for authentication:
+
+| Parameter   | Environment Variable Configuration           |
+| ----------- | -------------------------------------------- |
+| `api_key`   | `PARAMETER_API_KEY`, `ARTIFACTORY_API_KEY`   |
+| `password`  | `PARAMETER_PASSWORD`, `ARTIFACTORY_PASSWORD` |
+| `username`  | `PARAMETER_USERNAME`, `ARTIFACTORY_USERNAME` |
 
 Users can use [Vela internal secrets](https://go-vela.github.io/docs/tour/secrets/) to substitute these sensitive values at runtime:
 
@@ -144,13 +152,13 @@ steps:
 
 The plugin accepts the following files for authentication:
 
-| Parameter  | Volume Configuration                                                          |
+| Parameter  | File Configuration                                                            |
 | ---------- | ----------------------------------------------------------------------------- |
 | `api_key`  | `/vela/parameters/artifactory/api_key`, `/vela/secrets/artifactory/api_key`   |
 | `password` | `/vela/parameters/artifactory/password`, `/vela/secrets/artifactory/password` |
 | `username` | `/vela/parameters/artifactory/username`, `/vela/secrets/artifactory/username` |
 
-Users can use [Vela external secrets](https://go-vela.github.io/docs/concepts/pipeline/secrets/origin/) to substitute these sensitive values at runtime:
+Users can use [Vela external secrets](https://go-vela.github.io/docs/tour/secrets/) to substitute these sensitive values at runtime:
 
 ```diff
 steps:
@@ -166,15 +174,18 @@ steps:
 -     password: superSecretPassword
 ```
 
-> This example will read the secret values in the volume stored at `/vela/secrets/`
+> This example will read the secret values in the build workspace stored at `/vela/secrets/artifactory/*`
 
 ## Parameters
 
 > **NOTE:**
 >
-> The plugin supports reading all parameters via environment variables or files.
+> The plugin supports reading all parameters via:
 >
-> Any values set from a file take precedence over values set from the environment.
+> * environment variables - `PARAMETER_*` OR `ARTIFACTORY_*`
+> * files - `/vela/parameters/artifactory/*` OR `/vela/secrets/artifactory/*`
+>
+> Any values set from a file takes precedence over values set from the environment.
 
 The following parameters are used to configure the image:
 
@@ -186,9 +197,9 @@ The following parameters are used to configure the image:
 | `log_level` | set the log level for the plugin             | `true`   | `info`  | `PARAMETER_LOG_LEVEL`<br>`ARTIFACTORY_LOG_LEVEL` |
 | `password`  | password for communication with Artifactory  | `false`  | `N/A`   | `PARAMETER_PASSWORD`<br>`ARTIFACTORY_PASSWORD`   |
 | `url`       | Artifactory instance to communicate with     | `true`   | `N/A`   | `PARAMETER_URL`<br>`ARTIFACTORY_URL`             |
-| `username`  | user name for communication with Artifactory | `true`   | `N/A`   | `PARAMETER_USERNAME`<br>`ARTIFACTORY_USERNAME`   |
+| `username`  | user name for communication with Artifactory | `false`  | `N/A`   | `PARAMETER_USERNAME`<br>`ARTIFACTORY_USERNAME`   |
 
-#### Copy
+### Copy
 
 The following parameters are used to configure the `copy` action:
 
@@ -199,7 +210,7 @@ The following parameters are used to configure the `copy` action:
 | `recursive` | enables copying sub-directories for the artifact(s) | `false`  | `false` | `PARAMETER_RECURSIVE`<br>`ARTIFACTORY_RECURSIVE` |
 | `target`    | target path to copy artifact(s) to                  | `true`   | `N/A`   | `PARAMETER_TARGET`<br>`ARTIFACTORY_TARGET`       |
 
-#### Delete
+### Delete
 
 The following parameters are used to configure the `delete` action:
 
@@ -208,21 +219,21 @@ The following parameters are used to configure the `delete` action:
 | `path`      | target path to delete artifact(s) from               | `true`   | `N/A`   | `PARAMETER_PATH`<br>`ARTIFACTORY_PATH`           |
 | `recursive` | enables removing sub-directories for the artifact(s) | `false`  | `false` | `PARAMETER_RECURSIVE`<br>`ARTIFACTORY_RECURSIVE` |
 
-#### Docker-Promote
+### Docker-Promote
 
 The following parameters are used to configure the `docker-promote` action:
 
 | Name                     | Description                                         | Required | Default | Environment Variables                                                      |
 | ------------------------ | --------------------------------------------------- | -------- | ------- | -------------------------------------------------------------------------- |
-| `target_repo`            | name of the docker registry containing the image    | `true`   | `N/A`   | `PARAMETER_TARGET_REPO`<br>`ARTIFACTORY_TARGET_REPO`                       |
+| `copy`                   | set to copy instead of moving the image             | `false`  | `true`  | `PARAMETER_COPY`<br>`ARTIFACTORY_COPY`                                     |
 | `docker_registry`        | path to image in docker registry                    | `true`   | `N/A`   | `PARAMETER_DOCKER_REGISTRY`<br>`ARTIFACTORY_DOCKER_REGISTRY`               |
-| `target_docker_registry` | path for target image in docker registry            | `true`   | `N/A`   | `PARAMETER_TARGET_DOCKER_REGISTRY`<br>`ARTIFACTORY_TARGET_DOCKER_REGISTRY` |
-| `tag`                    | name of the tag for promoting                       | `true`   | `N/A`   | `PARAMETER_TAG`<br>`ARTIFACTORY_TAG`                                       |
-| `target_tags`            | name of the final tags after promotion              | `true`   | `N/A`   | `PARAMETER_TARGET_TAGS`<br>`ARTIFACTORY_TARGET_TAGS`                       |
-| `copy`                   | set to copy instead of moving the image             | `false`  | `false` | `PARAMETER_COPY`<br>`ARTIFACTORY_COPY`                                     |
 | `promote_props`          | enables setting properties on the promoted artifact | `false`  | `false` | `PARAMETER_PROMOTE_PROPS`<br>`ARTIFACTORY_PROMOTE_PROPS`                   |
+| `tag`                    | name of the tag for promoting                       | `true`   | `N/A`   | `PARAMETER_TAG`<br>`ARTIFACTORY_TAG`                                       |
+| `target_docker_registry` | path for target image in docker registry            | `true`   | `N/A`   | `PARAMETER_TARGET_DOCKER_REGISTRY`<br>`ARTIFACTORY_TARGET_DOCKER_REGISTRY` |
+| `target_repo`            | name of the docker registry containing the image    | `true`   | `N/A`   | `PARAMETER_TARGET_REPO`<br>`ARTIFACTORY_TARGET_REPO`                       |
+| `target_tags`            | name of the final tags after promotion              | `true`   | `N/A`   | `PARAMETER_TARGET_TAGS`<br>`ARTIFACTORY_TARGET_TAGS`                       |
 
-#### Set-Prop
+### Set-Prop
 
 The following parameters are used to configure the `set-prop` action:
 
@@ -231,7 +242,7 @@ The following parameters are used to configure the `set-prop` action:
 | `path`  | target path to artifact(s)           | `true`   | `N/A`   | `PARAMETER_PATH`<br>`ARTIFACTORY_PATH`   |
 | `props` | properties to set on the artifact(s) | `true`   | `N/A`   | `PARAMETER_PROPS`<br>`ARTIFACTORY_PROPS` |
 
-#### Upload
+### Upload
 
 The following parameters are used to configure the `upload` action:
 
@@ -240,8 +251,8 @@ The following parameters are used to configure the `upload` action:
 | `flat`         | enables removing source directory hierarchy           | `false`  | `false` | `PARAMETER_FLAT`<br>`ARTIFACTORY_FLAT`                 |
 | `include_dirs` | enables including sub-directories for the artifact(s) | `false`  | `false` | `PARAMETER_INCLUDE_DIRS`<br>`ARTIFACTORY_INCLUDE_DIRS` |
 | `path`         | target path to upload artifact(s) to                  | `true`   | `N/A`   | `PARAMETER_PATH`<br>`ARTIFACTORY_PATH`                 |
-| `recursive`    | enables uploading sub-directories for the artifact(s) | `false`  | `false` | `PARAMETER_REGEXP`<br>`ARTIFACTORY_REGEXP`             |
-| `regexp`       | enables reading the sources as a regular expression   | `false`  | `false` | `PARAMETER_RECURSIVE`<br>`ARTIFACTORY_RECURSIVE`       |
+| `recursive`    | enables uploading sub-directories for the artifact(s) | `false`  | `false` | `PARAMETER_RECURSIVE`<br>`ARTIFACTORY_RECURSIVE`       |
+| `regexp`       | enables reading the sources as a regular expression   | `false`  | `false` | `PARAMETER_REGEXP`<br>`ARTIFACTORY_REGEXP`             |
 | `sources`      | list of artifact(s) to upload                         | `true`   | `N/A`   | `PARAMETER_SOURCES`<br>`ARTIFACTORY_SOURCES`           |
 
 ## Template

--- a/DOCS.md
+++ b/DOCS.md
@@ -192,8 +192,8 @@ The following parameters are used to configure the image:
 | Name        | Description                                  | Required | Default | Environment Variables                            |
 | ----------- | -------------------------------------------- | -------- | ------- | ------------------------------------------------ |
 | `action`    | action to perform against Artifactory        | `true`   | `N/A`   | `PARAMETER_ACTION`<br>`ARTIFACTORY_ACTION`       |
-| `api_key`   | API key for communication with Artifactory   | `false`  | `N/A`   | `PARAMETER_DRY_RUN`<br>`ARTIFACTORY_DRY_RUN`     |
-| `dry_run`   | enables pretending to perform the action     | `false`  | `false` | `PARAMETER_API_KEY`<br>`ARTIFACTORY_API_KEY`     |
+| `api_key`   | API key for communication with Artifactory   | `false`  | `N/A`   | `PARAMETER_API_KEY`<br>`ARTIFACTORY_API_KEY`     |
+| `dry_run`   | enables pretending to perform the action     | `false`  | `false` | `PARAMETER_DRY_RUN`<br>`ARTIFACTORY_DRY_RUN`     |
 | `log_level` | set the log level for the plugin             | `true`   | `info`  | `PARAMETER_LOG_LEVEL`<br>`ARTIFACTORY_LOG_LEVEL` |
 | `password`  | password for communication with Artifactory  | `false`  | `N/A`   | `PARAMETER_PASSWORD`<br>`ARTIFACTORY_PASSWORD`   |
 | `url`       | Artifactory instance to communicate with     | `true`   | `N/A`   | `PARAMETER_URL`<br>`ARTIFACTORY_URL`             |


### PR DESCRIPTION
This contains a few changes:

* update reference to old environment variable `${BUILD_COMMIT:0:8}` -> `${VELA_BUILD_COMMIT:0:8}`
* calling out authentication `parameters` under internal secrets section
* adding clarification on plugin reading `parameters` from env vars and files
* fixed environment variables declared for `recursive` and `regexp` under Upload `parameters`
* fixed environment variables declared for `api_key` and `dry_run` under `parameters`