### PR TITLE
chore: update copyright year to 2022

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -28,7 +28,7 @@ Please see our [support](SUPPORT.md) documentation for further instructions.
 ## Copyright and License
 
 ```
-Copyright (c) 2021 Target Brands, Inc.
+Copyright (c) 2022 Target Brands, Inc.
 ```
 
 [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/.vela/template.yml
+++ b/.vela/template.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 
@@ -24,19 +24,19 @@ metadata:
 
 steps:
   - name: artifactory_plugin_template
-    image: {{ default "target/vela-artifactory:latest" .image }}
-    pull: {{ default "true" .pull }}
+    image: { { default "target/vela-artifactory:latest" .image } }
+    pull: { { default "true" .pull } }
     parameters:
-      log_level: {{ default "info" .log_level }}
-      action: {{ default "" .action }}
-      api_key: {{ default "" .api_key }}
-      dry_run: {{ default "false" .dry_run }}
-      flat: {{ default "false" .flat }}
-      include_dirs: {{ default "false" .include_dirs }}
-      path: {{ default "" .path }}
-      props: {{ default "" .props }}
-      recursive: {{ default "false" .recursive }}
-      regexp: {{ default "false" .regexp }}
-      sources: {{ default "" .sources }}
-      target: {{ default "" .target }}
-      url: {{ default "" .url }}
+      log_level: { { default "info" .log_level } }
+      action: { { default "" .action } }
+      api_key: { { default "" .api_key } }
+      dry_run: { { default "false" .dry_run } }
+      flat: { { default "false" .flat } }
+      include_dirs: { { default "false" .include_dirs } }
+      path: { { default "" .path } }
+      props: { { default "" .props } }
+      recursive: { { default "false" .recursive } }
+      regexp: { { default "false" .regexp } }
+      sources: { { default "" .sources } }
+      target: { { default "" .target } }
+      url: { { default "" .url } }

--- a/.vela/template.yml
+++ b/.vela/template.yml
@@ -2,7 +2,7 @@
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 
-## Template Variables
+### Template Variables
 # - .image        (default: "target/vela-artifactory:latest")
 # - .pull         (default: true)
 # - .log_level    (default: "info")
@@ -24,19 +24,19 @@ metadata:
 
 steps:
   - name: artifactory_plugin_template
-    image: { { default "target/vela-artifactory:latest" .image } }
-    pull: { { default "true" .pull } }
+    image: {{ default "target/vela-artifactory:latest" .image }}
+    pull: {{ default "true" .pull }}
     parameters:
-      log_level: { { default "info" .log_level } }
-      action: { { default "" .action } }
-      api_key: { { default "" .api_key } }
-      dry_run: { { default "false" .dry_run } }
-      flat: { { default "false" .flat } }
-      include_dirs: { { default "false" .include_dirs } }
-      path: { { default "" .path } }
-      props: { { default "" .props } }
-      recursive: { { default "false" .recursive } }
-      regexp: { { default "false" .regexp } }
-      sources: { { default "" .sources } }
-      target: { { default "" .target } }
-      url: { { default "" .url } }
+      log_level: {{ default "info" .log_level }}
+      action: {{ default "" .action }}
+      api_key: {{ default "" .api_key }}
+      dry_run: {{ default "false" .dry_run }}
+      flat: {{ default "false" .flat }}
+      include_dirs: {{ default "false" .include_dirs }}
+      path: {{ default "" .path }}
+      props: {{ default "" .props }}
+      recursive: {{ default "false" .recursive }}
+      regexp: {{ default "false" .regexp }}
+      sources: {{ default "" .sources }}
+      target: {{ default "" .target }}
+      url: {{ default "" .url }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2021 Target Brands, Inc.
+   Copyright (c) 2022 Target Brands, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-artifactory/config.go
+++ b/cmd/vela-artifactory/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-artifactory/config_test.go
+++ b/cmd/vela-artifactory/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-artifactory/copy.go
+++ b/cmd/vela-artifactory/copy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-artifactory/copy_test.go
+++ b/cmd/vela-artifactory/copy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-artifactory/delete.go
+++ b/cmd/vela-artifactory/delete.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-artifactory/delete_test.go
+++ b/cmd/vela-artifactory/delete_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-artifactory/docker_promote.go
+++ b/cmd/vela-artifactory/docker_promote.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-artifactory/docker_promote_test.go
+++ b/cmd/vela-artifactory/docker_promote_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-artifactory/main.go
+++ b/cmd/vela-artifactory/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
@@ -41,7 +41,7 @@ func main() {
 	app.Name = "vela-artifactory"
 	app.HelpName = "vela-artifactory"
 	app.Usage = "Vela Artifactory plugin for managing artifacts"
-	app.Copyright = "Copyright (c) 2021 Target Brands, Inc. All rights reserved."
+	app.Copyright = "Copyright (c) 2022 Target Brands, Inc. All rights reserved."
 	app.Authors = []*cli.Author{
 		{
 			Name:  "Vela Admins",

--- a/cmd/vela-artifactory/plugin.go
+++ b/cmd/vela-artifactory/plugin.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-artifactory/plugin_test.go
+++ b/cmd/vela-artifactory/plugin_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-artifactory/prop.go
+++ b/cmd/vela-artifactory/prop.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-artifactory/prop_test.go
+++ b/cmd/vela-artifactory/prop_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-artifactory/testdata/mock.go
+++ b/cmd/vela-artifactory/testdata/mock.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-artifactory/upload.go
+++ b/cmd/vela-artifactory/upload.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-artifactory/upload_test.go
+++ b/cmd/vela-artifactory/upload_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 


### PR DESCRIPTION
This is a general housekeeping task.
Used VS code's search and replace:
• Search: Copyright (c) 2021
• Replace: Copyright (c) 2022

At the top of every file, the new copyright statement now looks like:
`// Copyright (c) 2022 Target Brands, Inc. All rights reserved.`
