### PR TITLE
enhance: add retry loops to all artifactory api calls

### DIFF
--- a/cmd/vela-artifactory/copy.go
+++ b/cmd/vela-artifactory/copy.go
@@ -43,6 +43,7 @@ func (c *Copy) Exec(cli artifactory.ArtifactoryServicesManager) error {
 	p.Flat = c.Flat
 
 	retries := 3
+
 	var retryErr error
 
 	// send API call to copy artifacts in Artifactory

--- a/cmd/vela-artifactory/copy.go
+++ b/cmd/vela-artifactory/copy.go
@@ -46,7 +46,7 @@ func (c *Copy) Exec(cli artifactory.ArtifactoryServicesManager) error {
 	var retryErr error
 
 	// send API call to copy artifacts in Artifactory
-	// retry a couple times to avoid intermittent from Artifactory
+	// retry a couple times to avoid intermittent authentication failures from Artifactory
 	for i := 0; i < retries; i++ {
 		backoff := i*2 + 1
 

--- a/cmd/vela-artifactory/delete.go
+++ b/cmd/vela-artifactory/delete.go
@@ -73,8 +73,8 @@ func (d *Delete) Exec(cli artifactory.ArtifactoryServicesManager) error {
 		// send API call to delete artifacts in Artifactory
 		_, retryErr = cli.DeleteFiles(paths)
 		if retryErr != nil {
-			logrus.Errorf("Error deleting paths on attempt %d: %s",
-				i+1, retryErr.Error())
+			logrus.Errorf("Error deleting paths at %s on attempt %d: %s",
+				p.CommonParams.Pattern, i+1, retryErr.Error())
 
 			if i == retries-1 {
 				return retryErr

--- a/cmd/vela-artifactory/delete.go
+++ b/cmd/vela-artifactory/delete.go
@@ -38,7 +38,9 @@ func (d *Delete) Exec(cli artifactory.ArtifactoryServicesManager) error {
 	}
 
 	retries := 3
+
 	var retryErr error
+
 	var paths *content.ContentReader
 
 	// send API call to search for paths in Artifactory

--- a/cmd/vela-artifactory/delete.go
+++ b/cmd/vela-artifactory/delete.go
@@ -42,7 +42,7 @@ func (d *Delete) Exec(cli artifactory.ArtifactoryServicesManager) error {
 	var paths *content.ContentReader
 
 	// send API call to search for paths in Artifactory
-	// retry a couple times to avoid intermittent from Artifactory
+	// retry a couple times to avoid intermittent authentication failures from Artifactory
 	for i := 0; i < retries; i++ {
 		backoff := i*2 + 1
 
@@ -66,7 +66,7 @@ func (d *Delete) Exec(cli artifactory.ArtifactoryServicesManager) error {
 	}
 
 	// send API call to delete artifacts in Artifactory
-	// retry a couple times to avoid intermittent from Artifactory
+	// retry a couple times to avoid intermittent authentication failures from Artifactory
 	for i := 0; i < retries; i++ {
 		backoff := i*2 + 1
 

--- a/cmd/vela-artifactory/docker_promote.go
+++ b/cmd/vela-artifactory/docker_promote.go
@@ -91,7 +91,7 @@ func (p *DockerPromote) Exec(cli artifactory.ArtifactoryServicesManager) error {
 		var retryErr error
 
 		// send API call to promote Docker image in Artifactory
-		// retry a couple times to avoid intermittent from Artifactory
+		// retry a couple times to avoid intermittent authentication failures from Artifactory
 		for i := 0; i < retries; i++ {
 			backoff := i*2 + 1
 
@@ -145,7 +145,7 @@ func (p *DockerPromote) Exec(cli artifactory.ArtifactoryServicesManager) error {
 			var imageFolderReader *content.ContentReader
 
 			// send API call to search for files in Artifactory
-			// retry a couple times to avoid intermittent from Artifactory
+			// retry a couple times to avoid intermittent authentication failures from Artifactory
 			for i := 0; i < retries; i++ {
 				backoff := i*2 + 1
 
@@ -177,7 +177,7 @@ func (p *DockerPromote) Exec(cli artifactory.ArtifactoryServicesManager) error {
 			imageFolderSuccess := 0
 
 			// send API call to set properties on a Docker image folder in Artifactory
-			// retry a couple times to avoid intermittent from Artifactory
+			// retry a couple times to avoid intermittent authentication failures from Artifactory
 			for i := 0; i < retries; i++ {
 				backoff := i*2 + 1
 

--- a/cmd/vela-artifactory/docker_promote.go
+++ b/cmd/vela-artifactory/docker_promote.go
@@ -36,6 +36,8 @@ type DockerPromote struct {
 }
 
 // Exec formats and runs the commands for uploading artifacts in Artifactory.
+//
+//nolint:funlen // ignore function length
 func (p *DockerPromote) Exec(cli artifactory.ArtifactoryServicesManager) error {
 	logrus.Trace("running docker-promote with provided configuration")
 

--- a/cmd/vela-artifactory/docker_promote.go
+++ b/cmd/vela-artifactory/docker_promote.go
@@ -88,6 +88,7 @@ func (p *DockerPromote) Exec(cli artifactory.ArtifactoryServicesManager) error {
 		logrus.Infof("Promoting tag %s to target %s", payload.GetSourceTag(), payload.GetTargetTag())
 
 		retries := 3
+
 		var retryErr error
 
 		// send API call to promote Docker image in Artifactory

--- a/cmd/vela-artifactory/prop.go
+++ b/cmd/vela-artifactory/prop.go
@@ -86,6 +86,7 @@ func (s *SetProp) Exec(cli artifactory.ArtifactoryServicesManager) error {
 	retries := 3
 
 	var retryErr error
+
 	var files *content.ContentReader
 
 	// send API call to search for files in Artifactory

--- a/cmd/vela-artifactory/prop.go
+++ b/cmd/vela-artifactory/prop.go
@@ -88,7 +88,7 @@ func (s *SetProp) Exec(cli artifactory.ArtifactoryServicesManager) error {
 	var files *content.ContentReader
 
 	// send API call to search for files in Artifactory
-	// retry a couple times to avoid intermittent from Artifactory
+	// retry a couple times to avoid intermittent authentication failures from Artifactory
 	for i := 0; i < retries; i++ {
 		backoff := i*2 + 1
 
@@ -118,7 +118,7 @@ func (s *SetProp) Exec(cli artifactory.ArtifactoryServicesManager) error {
 	p.Props = s.String()
 
 	// send API call to upload files in Artifactory
-	// retry a couple times to avoid intermittent from Artifactory
+	// retry a couple times to avoid intermittent authentication failures from Artifactory
 	for i := 0; i < retries; i++ {
 		backoff := i*2 + 1
 

--- a/cmd/vela-artifactory/prop.go
+++ b/cmd/vela-artifactory/prop.go
@@ -84,6 +84,7 @@ func (s *SetProp) Exec(cli artifactory.ArtifactoryServicesManager) error {
 	}
 
 	retries := 3
+
 	var retryErr error
 	var files *content.ContentReader
 

--- a/cmd/vela-artifactory/upload.go
+++ b/cmd/vela-artifactory/upload.go
@@ -51,6 +51,7 @@ func (u *Upload) Exec(cli artifactory.ArtifactoryServicesManager) error {
 		p.Flat = u.Flat
 
 		retries := 3
+
 		var retryErr error
 		totalFailed := 0
 		totalSucceeded := 0

--- a/cmd/vela-artifactory/upload.go
+++ b/cmd/vela-artifactory/upload.go
@@ -57,7 +57,7 @@ func (u *Upload) Exec(cli artifactory.ArtifactoryServicesManager) error {
 		maxSucceeded := 0
 
 		// send API call to upload files in Artifactory
-		// retry a couple times to avoid intermittent from Artifactory
+		// retry a couple times to avoid intermittent authentication failures from Artifactory
 		for i := 0; i < retries; i++ {
 			backoff := i*2 + 1
 

--- a/cmd/vela-artifactory/upload.go
+++ b/cmd/vela-artifactory/upload.go
@@ -51,11 +51,11 @@ func (u *Upload) Exec(cli artifactory.ArtifactoryServicesManager) error {
 		p.Flat = u.Flat
 
 		retries := 3
-
-		var retryErr error
 		totalFailed := 0
 		totalSucceeded := 0
 		maxSucceeded := 0
+
+		var retryErr error
 
 		// send API call to upload files in Artifactory
 		// retry a couple times to avoid intermittent authentication failures from Artifactory


### PR DESCRIPTION
this should help with stability against intermittent authentication failures that can be seen with the artifactory api. mostly errors that are due to external factors, but its often enough to make this necessary.