### PR TITLE
fix: build props config

### DIFF
--- a/cmd/vela-artifactory/main.go
+++ b/cmd/vela-artifactory/main.go
@@ -258,7 +258,7 @@ func main() {
 			Name:     "upload.sources",
 			Usage:    "list of artifact(s) to upload",
 		},
-		&cli.StringSliceFlag{
+		&cli.StringFlag{
 			EnvVars:  []string{"PARAMETER_BUILD_PROPS", "ARTIFACTORY_BUILD_PROPS"},
 			FilePath: "/vela/parameters/artifactory/build_props,/vela/secrets/artifactory/build_props",
 			Name:     "upload.build_props",


### PR DESCRIPTION
used the wrong type for the flag so the zero value was converted to a string of "[]" which caused errors for the build props being a wrong format when not defined. probably an opportunity to rewrite tests to use cli config instead of building config structs ourselves.